### PR TITLE
feat(node): upgrade to node version 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
     description: 'Credential to access to the repo to post the comment'
     default: ${{ github.token }}
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'archive'


### PR DESCRIPTION
Node.js 12 GitHub Actions are now deprecated => upgrade to 16.